### PR TITLE
レシート一覧を年月でフィルタリング表示

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,16 @@ app/google-services.json
 .externalNativeBuild
 .cxx
 local.properties
+
+# Claude Code / AI tools
+.claude/
+.serena/
+
+# Environment
+.env
+
+# Build outputs
+app/release/
+
+# Work in progress docs
+docs/wip/

--- a/app/src/main/java/net/uoneweb/android/til/ShareReceiverActivity.kt
+++ b/app/src/main/java/net/uoneweb/android/til/ShareReceiverActivity.kt
@@ -112,13 +112,12 @@ class ShareReceiverActivity : AppCompatActivity() {
     suspend fun saveMultipleReceipts(list: List<ReceiptMetaData>) {
         var cnt = 0
         for (receipt in list) {
-            val data = ReceiptMetaData.fromJson(receipt.toString())
-            val id = receiptMetaDataRepository.insert(data)
+            val id = receiptMetaDataRepository.insert(receipt)
             if (id >= 0) {
                 cnt++
                 Log.d("handleJson", "Inserted receipt with ID: $id")
             } else {
-                Log.e("handleJson", "Failed to insert receipt: $data")
+                Log.e("handleJson", "Failed to insert receipt: $receipt")
             }
         }
         Log.d("handleJson", "Inserted $cnt/${list.size} receipts")

--- a/receipt/src/main/java/net/uoneweb/android/data/AppDatabase.kt
+++ b/receipt/src/main/java/net/uoneweb/android/data/AppDatabase.kt
@@ -8,7 +8,7 @@ import net.uoneweb.android.receipt.dto.ReceiptMappingInfoEntity
 import net.uoneweb.android.receipt.dto.ReceiptMetaDataDao
 import net.uoneweb.android.receipt.dto.ReceiptMetaDataEntity
 
-@Database(entities = [ReceiptMetaDataEntity::class, ReceiptMappingInfoEntity::class], version = 1)
+@Database(entities = [ReceiptMetaDataEntity::class, ReceiptMappingInfoEntity::class], version = 2)
 @TypeConverters(LocationConverter::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun receiptMetaDataDao(): ReceiptMetaDataDao

--- a/receipt/src/main/java/net/uoneweb/android/data/DatabaseProvider.kt
+++ b/receipt/src/main/java/net/uoneweb/android/data/DatabaseProvider.kt
@@ -2,9 +2,45 @@ package net.uoneweb.android.data
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.google.gson.JsonParser
 
 object DatabaseProvider {
     private var instance: AppDatabase? = null
+
+    private val MIGRATION_1_2 = object : Migration(1, 2) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            // 新しいカラムを追加
+            db.execSQL("ALTER TABLE receipt_metadata ADD COLUMN receiptDate TEXT")
+            db.execSQL("ALTER TABLE receipt_metadata ADD COLUMN receiptYearMonth TEXT")
+
+            // 既存データのcontentからdateを抽出して設定
+            val cursor = db.query("SELECT id, content FROM receipt_metadata")
+            while (cursor.moveToNext()) {
+                val id = cursor.getLong(0)
+                val content = cursor.getString(1)
+                try {
+                    val jsonObj = JsonParser.parseString(content).asJsonObject
+                    val receiptObj = jsonObj.getAsJsonObject("receipt")
+                    val date = receiptObj?.get("date")?.asString
+                    if (!date.isNullOrEmpty()) {
+                        val yearMonth = date.take(7)
+                        db.execSQL(
+                            "UPDATE receipt_metadata SET receiptDate = ?, receiptYearMonth = ? WHERE id = ?",
+                            arrayOf(date, yearMonth, id),
+                        )
+                    }
+                } catch (e: Exception) {
+                    // JSONパース失敗時は無視
+                }
+            }
+            cursor.close()
+
+            // インデックスを作成
+            db.execSQL("CREATE INDEX IF NOT EXISTS index_receipt_metadata_receiptYearMonth ON receipt_metadata(receiptYearMonth)")
+        }
+    }
 
     fun getDatabase(context: Context): AppDatabase {
         if (instance == null) {
@@ -13,6 +49,7 @@ object DatabaseProvider {
                 AppDatabase::class.java,
                 "app_database",
             )
+                .addMigrations(MIGRATION_1_2)
                 .build()
         }
         return instance!!

--- a/receipt/src/main/java/net/uoneweb/android/data/DatabaseProvider.kt
+++ b/receipt/src/main/java/net/uoneweb/android/data/DatabaseProvider.kt
@@ -1,6 +1,7 @@
 package net.uoneweb.android.data
 
 import android.content.Context
+import android.util.Log
 import androidx.room.Room
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
@@ -32,7 +33,7 @@ object DatabaseProvider {
                         )
                     }
                 } catch (e: Exception) {
-                    // JSONパース失敗時は無視
+                    Log.e("DatabaseProvider", "Migration failed to parse JSON for id=$id", e)
                 }
             }
             cursor.close()

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ReceiptConstants.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ReceiptConstants.kt
@@ -1,0 +1,12 @@
+package net.uoneweb.android.receipt
+
+import java.util.Calendar
+
+const val UNKNOWN_DATE_KEY = "__unknown__"
+
+fun currentYearMonth(): String {
+    val now = Calendar.getInstance()
+    val year = now.get(Calendar.YEAR)
+    val month = now.get(Calendar.MONTH) + 1
+    return String.format("%04d-%02d", year, month)
+}

--- a/receipt/src/main/java/net/uoneweb/android/receipt/dto/ReceiptMetaDataDao.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/dto/ReceiptMetaDataDao.kt
@@ -19,6 +19,21 @@ interface ReceiptMetaDataDao {
     @Query("SELECT * FROM receipt_metadata")
     fun getAll(): Flow<List<ReceiptMetaDataEntity>>
 
+    @Query("SELECT DISTINCT receiptYearMonth FROM receipt_metadata WHERE receiptYearMonth IS NOT NULL ORDER BY receiptYearMonth DESC")
+    fun getYearMonthList(): Flow<List<String>>
+
+    @Query("SELECT * FROM receipt_metadata WHERE receiptYearMonth = :yearMonth ORDER BY receiptDate DESC")
+    fun getByYearMonth(yearMonth: String): Flow<List<ReceiptMetaDataEntity>>
+
+    @Query("SELECT * FROM receipt_metadata WHERE receiptYearMonth IS NULL ORDER BY id DESC")
+    fun getUnknownDate(): Flow<List<ReceiptMetaDataEntity>>
+
+    @Query("SELECT COUNT(*) FROM receipt_metadata WHERE receiptYearMonth = :yearMonth")
+    fun getCountByYearMonth(yearMonth: String): Flow<Int>
+
+    @Query("SELECT COUNT(*) FROM receipt_metadata WHERE receiptYearMonth IS NULL")
+    fun getCountUnknownDate(): Flow<Int>
+
     @Update
     suspend fun update(metadata: ReceiptMetaDataEntity)
 

--- a/receipt/src/main/java/net/uoneweb/android/receipt/dto/ReceiptMetaDataEntity.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/dto/ReceiptMetaDataEntity.kt
@@ -1,25 +1,35 @@
 package net.uoneweb.android.receipt.dto
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import net.uoneweb.android.data.LocationConverter
 import net.uoneweb.android.receipt.data.Receipt
 import net.uoneweb.android.receipt.data.ReceiptMetaData
 
-@Entity(tableName = "receipt_metadata")
+@Entity(
+    tableName = "receipt_metadata",
+    indices = [Index(value = ["receiptYearMonth"])],
+)
 data class ReceiptMetaDataEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val content: String, // ReceiptのJSON文字列
     val location: String?, // LocationのJSON文字列
     val filename: String?,
+    val receiptDate: String? = null, // "YYYY-MM-DD" 形式
+    val receiptYearMonth: String? = null, // "YYYY-MM" 形式
 ) {
     companion object {
         fun fromReceiptMetaData(metadata: ReceiptMetaData): ReceiptMetaDataEntity {
+            val date = metadata.content.receipt.date.takeIf { it.isNotEmpty() }
+            val yearMonth = date?.take(7) // "YYYY-MM-DD" -> "YYYY-MM"
             return ReceiptMetaDataEntity(
                 id = metadata.id ?: 0,
                 content = metadata.content.json,
                 location = metadata.location?.let { LocationConverter.toJson(it) },
                 filename = metadata.filename,
+                receiptDate = date,
+                receiptYearMonth = yearMonth,
             )
         }
 

--- a/receipt/src/main/java/net/uoneweb/android/receipt/repository/ReceiptMetaDataRepository.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/repository/ReceiptMetaDataRepository.kt
@@ -27,6 +27,30 @@ class ReceiptMetaDataRepository(context: Context) {
         }
     }
 
+    fun getYearMonthList(): Flow<List<String>> {
+        return dao.getYearMonthList()
+    }
+
+    fun getByYearMonth(yearMonth: String): Flow<List<ReceiptMetaData>> {
+        return dao.getByYearMonth(yearMonth).map { entities ->
+            entities.map { ReceiptMetaDataEntity.toReceiptMetaData(it) }
+        }
+    }
+
+    fun getUnknownDate(): Flow<List<ReceiptMetaData>> {
+        return dao.getUnknownDate().map { entities ->
+            entities.map { ReceiptMetaDataEntity.toReceiptMetaData(it) }
+        }
+    }
+
+    fun getCountByYearMonth(yearMonth: String): Flow<Int> {
+        return dao.getCountByYearMonth(yearMonth)
+    }
+
+    fun getCountUnknownDate(): Flow<Int> {
+        return dao.getCountUnknownDate()
+    }
+
     suspend fun update(id: Long, metadata: ReceiptMetaData) = withContext(Dispatchers.IO) {
         val entity = ReceiptMetaDataEntity.fromReceiptMetaData(metadata)
         dao.update(entity)

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/ReceiptScreen.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/ReceiptScreen.kt
@@ -67,6 +67,7 @@ fun ReceiptScreen(viewModel: ReceiptViewModel = viewModel()) {
                 }
             },
             receiptDetailUiState = receiptDetailUiState,
+            receiptViewModel = viewModel,
             onReceiptDetailEvent = { event ->
                 coroutineScope.launch {
                     when (event) {
@@ -117,6 +118,7 @@ fun ReceiptScreenMain(
     onReceiptDetailEvent: (receiptDetailEvent: ReceiptDetailEvent) -> Unit = {},
     receiptMappingUiState: ReceiptMappingUiState = ReceiptMappingUiState(),
     onReceiptMappingEvent: (ReceiptMappingEvent) -> Unit = {},
+    receiptViewModel: ReceiptViewModel? = null,
 ) {
 
     val scrollState = rememberScrollState()
@@ -145,13 +147,24 @@ fun ReceiptScreenMain(
             }
             when (selectedTabIndex) {
                 0 -> {
-                    ReceiptList(
-                        list,
-                        onClickItem = {
-                            onClickItem(it)
-                            selectedTabIndex = 1
-                        },
-                    )
+                    if (receiptViewModel != null) {
+                        ReceiptList(
+                            list,
+                            onClickItem = {
+                                onClickItem(it)
+                                selectedTabIndex = 1
+                            },
+                            viewModel = receiptViewModel,
+                        )
+                    } else {
+                        ReceiptList(
+                            list,
+                            onClickItem = {
+                                onClickItem(it)
+                                selectedTabIndex = 1
+                            },
+                        )
+                    }
                 }
 
                 1 -> {

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/ReceiptScreen.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/ReceiptScreen.kt
@@ -57,22 +57,7 @@ fun ReceiptScreen(viewModel: ReceiptViewModel = viewModel()) {
         location = receiptDetailUiState.receipt.location ?: Location.Default,
     )
 
-    // ReceiptList用の状態を収集
-    val yearMonthList by viewModel.yearMonthList.collectAsState()
-    val unknownDateCount by viewModel.unknownDateCount.collectAsState()
-    val selectedYearMonth by viewModel.selectedYearMonth.collectAsState()
-    val selectedReceipts by viewModel.getReceiptsForMonth(selectedYearMonth).collectAsState()
-
-    val receiptListState = ReceiptListState(
-        yearMonthOptions = buildList {
-            addAll(yearMonthList)
-            if (unknownDateCount > 0) {
-                add(ReceiptListState.UNKNOWN_DATE_KEY)
-            }
-        },
-        selectedYearMonth = selectedYearMonth,
-        receipts = selectedReceipts,
-    )
+    val receiptListState by viewModel.receiptListState.collectAsState()
 
     Column {
         ReceiptScreenMain(

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/ReceiptScreen.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/ReceiptScreen.kt
@@ -38,12 +38,12 @@ import net.uoneweb.android.receipt.ui.detail.ReceiptDetail
 import net.uoneweb.android.receipt.ui.detail.ReceiptDetailEvent
 import net.uoneweb.android.receipt.ui.detail.ReceiptDetailUiState
 import net.uoneweb.android.receipt.ui.list.ReceiptList
+import net.uoneweb.android.receipt.ui.list.ReceiptListState
 
 @Composable
 fun ReceiptScreen(viewModel: ReceiptViewModel = viewModel()) {
     val receiptMappingInfo by viewModel.osmInfoJson
     val receiptMetaDataList = viewModel.listReceiptMetaData.collectAsState()
-    //val receiptMappingInfoList = viewModel.listReceiptMappingInfosByReceiptId(receipt.id ?: 0).collectAsState()
     val receiptMappingInfoList = viewModel.listReceiptMappingInfos().collectAsState()
     val coroutineScope = rememberCoroutineScope()
 
@@ -57,6 +57,23 @@ fun ReceiptScreen(viewModel: ReceiptViewModel = viewModel()) {
         location = receiptDetailUiState.receipt.location ?: Location.Default,
     )
 
+    // ReceiptList用の状態を収集
+    val yearMonthList by viewModel.yearMonthList.collectAsState()
+    val unknownDateCount by viewModel.unknownDateCount.collectAsState()
+    val selectedYearMonth by viewModel.selectedYearMonth.collectAsState()
+    val selectedReceipts by viewModel.getReceiptsForMonth(selectedYearMonth).collectAsState()
+
+    val receiptListState = ReceiptListState(
+        yearMonthOptions = buildList {
+            addAll(yearMonthList)
+            if (unknownDateCount > 0) {
+                add(ReceiptListState.UNKNOWN_DATE_KEY)
+            }
+        },
+        selectedYearMonth = selectedYearMonth,
+        receipts = selectedReceipts,
+    )
+
     Column {
         ReceiptScreenMain(
             list = receiptMetaDataList.value,
@@ -67,7 +84,8 @@ fun ReceiptScreen(viewModel: ReceiptViewModel = viewModel()) {
                 }
             },
             receiptDetailUiState = receiptDetailUiState,
-            receiptViewModel = viewModel,
+            receiptListState = receiptListState,
+            onYearMonthSelected = { viewModel.selectYearMonth(it) },
             onReceiptDetailEvent = { event ->
                 coroutineScope.launch {
                     when (event) {
@@ -118,7 +136,8 @@ fun ReceiptScreenMain(
     onReceiptDetailEvent: (receiptDetailEvent: ReceiptDetailEvent) -> Unit = {},
     receiptMappingUiState: ReceiptMappingUiState = ReceiptMappingUiState(),
     onReceiptMappingEvent: (ReceiptMappingEvent) -> Unit = {},
-    receiptViewModel: ReceiptViewModel? = null,
+    receiptListState: ReceiptListState = ReceiptListState(),
+    onYearMonthSelected: (String) -> Unit = {},
 ) {
 
     val scrollState = rememberScrollState()
@@ -147,24 +166,14 @@ fun ReceiptScreenMain(
             }
             when (selectedTabIndex) {
                 0 -> {
-                    if (receiptViewModel != null) {
-                        ReceiptList(
-                            list,
-                            onClickItem = {
-                                onClickItem(it)
-                                selectedTabIndex = 1
-                            },
-                            viewModel = receiptViewModel,
-                        )
-                    } else {
-                        ReceiptList(
-                            list,
-                            onClickItem = {
-                                onClickItem(it)
-                                selectedTabIndex = 1
-                            },
-                        )
-                    }
+                    ReceiptList(
+                        state = receiptListState,
+                        onYearMonthSelected = onYearMonthSelected,
+                        onClickItem = {
+                            onClickItem(it)
+                            selectedTabIndex = 1
+                        },
+                    )
                 }
 
                 1 -> {
@@ -245,5 +254,10 @@ fun ReceiptScreenMainPreview() {
             ReceiptMetaData(Receipt.Empty),
         ),
         receiptDetailUiState = receiptDetailUiState,
+        receiptListState = ReceiptListState(
+            yearMonthOptions = listOf("2025-01"),
+            selectedYearMonth = "2025-01",
+            receipts = listOf(ReceiptMetaData(Receipt.Sample)),
+        ),
     )
 }

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/ReceiptViewModel.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/ReceiptViewModel.kt
@@ -61,6 +61,15 @@ class ReceiptViewModel(application: Application) : AndroidViewModel(application)
     private val _osmInfoJson: MutableState<String> = mutableStateOf("")
     val osmInfoJson: State<String> = _osmInfoJson
 
+    private val _selectedYearMonth = MutableStateFlow(getCurrentYearMonth())
+    val selectedYearMonth: StateFlow<String> = _selectedYearMonth.asStateFlow()
+
+    private fun getCurrentYearMonth(): String {
+        val now = java.util.Calendar.getInstance()
+        val year = now.get(java.util.Calendar.YEAR)
+        val month = now.get(java.util.Calendar.MONTH) + 1
+        return String.format("%04d-%02d", year, month)
+    }
 
     init {
         this.viewModelScope.launch {
@@ -88,6 +97,42 @@ class ReceiptViewModel(application: Application) : AndroidViewModel(application)
         started = SharingStarted.Lazily,
         initialValue = emptyList(),
     )
+
+    val yearMonthList: StateFlow<List<String>> = receiptMetaDataRepository.getYearMonthList().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Lazily,
+        initialValue = emptyList(),
+    )
+
+    val unknownDateCount: StateFlow<Int> = receiptMetaDataRepository.getCountUnknownDate().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Lazily,
+        initialValue = 0,
+    )
+
+    private val receiptsCache = mutableMapOf<String, StateFlow<List<ReceiptMetaData>>>()
+
+    fun getReceiptsForMonth(yearMonth: String): StateFlow<List<ReceiptMetaData>> {
+        return receiptsCache.getOrPut(yearMonth) {
+            if (yearMonth == UNKNOWN_DATE_KEY) {
+                receiptMetaDataRepository.getUnknownDate()
+            } else {
+                receiptMetaDataRepository.getByYearMonth(yearMonth)
+            }.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.Lazily,
+                initialValue = emptyList(),
+            )
+        }
+    }
+
+    fun selectYearMonth(yearMonth: String) {
+        _selectedYearMonth.value = yearMonth
+    }
+
+    companion object {
+        const val UNKNOWN_DATE_KEY = "__unknown__"
+    }
 
     fun listReceiptMappingInfos(): StateFlow<List<ReceiptMappingInfo>> =
         receiptMappingInfoRepository.getAll()

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/ReceiptViewModel.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/ReceiptViewModel.kt
@@ -13,14 +13,18 @@ import com.google.firebase.ai.ai
 import com.google.firebase.ai.type.GenerativeBackend
 import com.google.firebase.ai.type.content
 import com.google.firebase.storage.storage
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import net.uoneweb.android.receipt.ui.list.ReceiptListState
 import net.uoneweb.android.data.ReceiptSettingDataStore
 import net.uoneweb.android.gis.ui.location.Location
 import net.uoneweb.android.gis.ui.map.Feature
@@ -45,6 +49,7 @@ import retrofit2.Callback
 import retrofit2.Response
 
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ReceiptViewModel(application: Application) : AndroidViewModel(application) {
     private val receiptMetaDataRepository = ReceiptMetaDataRepository(application)
     private val receiptMappingInfoRepository = ReceiptMappingInfoRepository(application)
@@ -129,6 +134,36 @@ class ReceiptViewModel(application: Application) : AndroidViewModel(application)
     fun selectYearMonth(yearMonth: String) {
         _selectedYearMonth.value = yearMonth
     }
+
+    private val selectedReceiptsFlow = _selectedYearMonth.flatMapLatest { yearMonth ->
+        if (yearMonth == UNKNOWN_DATE_KEY) {
+            receiptMetaDataRepository.getUnknownDate()
+        } else {
+            receiptMetaDataRepository.getByYearMonth(yearMonth)
+        }
+    }
+
+    val receiptListState: StateFlow<ReceiptListState> = combine(
+        yearMonthList,
+        unknownDateCount,
+        _selectedYearMonth,
+        selectedReceiptsFlow,
+    ) { yearMonthList, unknownCount, selectedYearMonth, receipts ->
+        ReceiptListState(
+            yearMonthOptions = buildList {
+                addAll(yearMonthList)
+                if (unknownCount > 0) {
+                    add(UNKNOWN_DATE_KEY)
+                }
+            },
+            selectedYearMonth = selectedYearMonth,
+            receipts = receipts,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = ReceiptListState(),
+    )
 
     companion object {
         const val UNKNOWN_DATE_KEY = "__unknown__"

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/ReceiptViewModel.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/ReceiptViewModel.kt
@@ -24,6 +24,8 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import net.uoneweb.android.receipt.UNKNOWN_DATE_KEY
+import net.uoneweb.android.receipt.currentYearMonth
 import net.uoneweb.android.receipt.ui.list.ReceiptListState
 import net.uoneweb.android.data.ReceiptSettingDataStore
 import net.uoneweb.android.gis.ui.location.Location
@@ -66,15 +68,8 @@ class ReceiptViewModel(application: Application) : AndroidViewModel(application)
     private val _osmInfoJson: MutableState<String> = mutableStateOf("")
     val osmInfoJson: State<String> = _osmInfoJson
 
-    private val _selectedYearMonth = MutableStateFlow(getCurrentYearMonth())
+    private val _selectedYearMonth = MutableStateFlow(currentYearMonth())
     val selectedYearMonth: StateFlow<String> = _selectedYearMonth.asStateFlow()
-
-    private fun getCurrentYearMonth(): String {
-        val now = java.util.Calendar.getInstance()
-        val year = now.get(java.util.Calendar.YEAR)
-        val month = now.get(java.util.Calendar.MONTH) + 1
-        return String.format("%04d-%02d", year, month)
-    }
 
     init {
         this.viewModelScope.launch {
@@ -115,22 +110,6 @@ class ReceiptViewModel(application: Application) : AndroidViewModel(application)
         initialValue = 0,
     )
 
-    private val receiptsCache = mutableMapOf<String, StateFlow<List<ReceiptMetaData>>>()
-
-    fun getReceiptsForMonth(yearMonth: String): StateFlow<List<ReceiptMetaData>> {
-        return receiptsCache.getOrPut(yearMonth) {
-            if (yearMonth == UNKNOWN_DATE_KEY) {
-                receiptMetaDataRepository.getUnknownDate()
-            } else {
-                receiptMetaDataRepository.getByYearMonth(yearMonth)
-            }.stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.Lazily,
-                initialValue = emptyList(),
-            )
-        }
-    }
-
     fun selectYearMonth(yearMonth: String) {
         _selectedYearMonth.value = yearMonth
     }
@@ -164,10 +143,6 @@ class ReceiptViewModel(application: Application) : AndroidViewModel(application)
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = ReceiptListState(),
     )
-
-    companion object {
-        const val UNKNOWN_DATE_KEY = "__unknown__"
-    }
 
     fun listReceiptMappingInfos(): StateFlow<List<ReceiptMappingInfo>> =
         receiptMappingInfoRepository.getAll()

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptList.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptList.kt
@@ -1,54 +1,118 @@
 package net.uoneweb.android.receipt.ui.list
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import net.uoneweb.android.receipt.R
 import net.uoneweb.android.receipt.data.ReceiptMetaData
+import net.uoneweb.android.receipt.ui.ReceiptViewModel
 
-
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ReceiptList(list: List<ReceiptMetaData> = emptyList(), onClickItem: (item: ReceiptMetaData) -> Unit = {}) {
-    val sortedList = list.sortedWith { lsv, rsv ->
-        if (lsv.content.title() < rsv.content.title()) {
-            1
-        } else if (lsv.content.title() > rsv.content.title()) {
-            -1
-        } else {
-            0
+fun ReceiptList(
+    list: List<ReceiptMetaData> = emptyList(),
+    onClickItem: (item: ReceiptMetaData) -> Unit = {},
+    viewModel: ReceiptViewModel = viewModel(),
+) {
+    val yearMonthList by viewModel.yearMonthList.collectAsState()
+    val unknownDateCount by viewModel.unknownDateCount.collectAsState()
+    val selectedYearMonth by viewModel.selectedYearMonth.collectAsState()
+
+    val allOptions = buildList {
+        addAll(yearMonthList)
+        if (unknownDateCount > 0) {
+            add(ReceiptViewModel.UNKNOWN_DATE_KEY)
+        }
+    }
+
+    val receipts by viewModel.getReceiptsForMonth(selectedYearMonth).collectAsState()
+
+    var expanded by remember { mutableStateOf(false) }
+
+    Column {
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+        ) {
+            TextField(
+                value = formatYearMonth(selectedYearMonth),
+                onValueChange = {},
+                readOnly = true,
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                modifier = Modifier
+                    .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                    .fillMaxWidth(),
+            )
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+            ) {
+                allOptions.forEach { yearMonth ->
+                    DropdownMenuItem(
+                        text = { Text(formatYearMonth(yearMonth)) },
+                        onClick = {
+                            viewModel.selectYearMonth(yearMonth)
+                            expanded = false
+                        },
+                    )
+                }
+            }
         }
 
-    }
-    Column {
-        sortedList.forEach { item ->
+        receipts.forEach { item ->
             ReceiptListItem(item, onClickItem)
         }
     }
 }
 
 @Composable
-fun ReceiptListItem(item: ReceiptMetaData = ReceiptMetaData.Empty, onClickItem: (item: ReceiptMetaData) -> Unit = {}) {
-    Row(
-        modifier = Modifier
-            .padding(8.dp)
-            .clickable {
-                onClickItem(item)
-            },
-    ) {
-        Text(item.content.title(), style = MaterialTheme.typography.bodyMedium)
+private fun formatYearMonth(yearMonth: String): String {
+    return if (yearMonth == ReceiptViewModel.UNKNOWN_DATE_KEY) {
+        stringResource(R.string.list_unknown_date)
+    } else {
+        yearMonth.replace("-", "年") + "月"
     }
 }
 
-@Preview(showBackground = true)
 @Composable
-fun ReceiptListPreview() {
-    ReceiptList(listOf(ReceiptMetaData.Sample, ReceiptMetaData.Empty))
+fun ReceiptListItem(
+    item: ReceiptMetaData = ReceiptMetaData.Empty,
+    onClickItem: (item: ReceiptMetaData) -> Unit = {},
+) {
+    Row(
+        modifier = Modifier
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+            .fillMaxWidth()
+            .clickable { onClickItem(item) },
+    ) {
+        Text(item.content.title(), style = MaterialTheme.typography.bodyMedium)
+    }
 }
 
 @Preview(showBackground = true)

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptList.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptList.kt
@@ -35,50 +35,65 @@ data class ReceiptListState(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReceiptList(
     state: ReceiptListState,
     onYearMonthSelected: (String) -> Unit = {},
     onClickItem: (ReceiptMetaData) -> Unit = {},
 ) {
-    var expanded by remember { mutableStateOf(false) }
-
     Column {
-        ExposedDropdownMenuBox(
-            expanded = expanded,
-            onExpandedChange = { expanded = it },
+        YearMonthDropdown(
+            options = state.yearMonthOptions,
+            selectedYearMonth = state.selectedYearMonth,
+            onYearMonthSelected = onYearMonthSelected,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(8.dp),
-        ) {
-            TextField(
-                value = formatYearMonth(state.selectedYearMonth),
-                onValueChange = {},
-                readOnly = true,
-                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-                modifier = Modifier
-                    .menuAnchor(MenuAnchorType.PrimaryNotEditable)
-                    .fillMaxWidth(),
-            )
-            ExposedDropdownMenu(
-                expanded = expanded,
-                onDismissRequest = { expanded = false },
-            ) {
-                state.yearMonthOptions.forEach { yearMonth ->
-                    DropdownMenuItem(
-                        text = { Text(formatYearMonth(yearMonth)) },
-                        onClick = {
-                            onYearMonthSelected(yearMonth)
-                            expanded = false
-                        },
-                    )
-                }
-            }
-        }
+        )
 
         state.receipts.forEach { item ->
             ReceiptListItem(item, onClickItem)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun YearMonthDropdown(
+    options: List<String>,
+    selectedYearMonth: String,
+    onYearMonthSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        TextField(
+            value = formatYearMonth(selectedYearMonth),
+            onValueChange = {},
+            readOnly = true,
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .fillMaxWidth(),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            options.forEach { yearMonth ->
+                DropdownMenuItem(
+                    text = { Text(formatYearMonth(yearMonth)) },
+                    onClick = {
+                        onYearMonthSelected(yearMonth)
+                        expanded = false
+                    },
+                )
+            }
         }
     }
 }
@@ -116,6 +131,16 @@ fun ReceiptListPreview() {
             selectedYearMonth = "2025-01",
             receipts = listOf(ReceiptMetaData.Sample),
         ),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun YearMonthDropdownPreview() {
+    YearMonthDropdown(
+        options = listOf("2025-01", "2025-02", ReceiptListState.UNKNOWN_DATE_KEY),
+        selectedYearMonth = "2025-01",
+        onYearMonthSelected = {},
     )
 }
 

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptList.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptList.kt
@@ -1,12 +1,10 @@
 package net.uoneweb.android.receipt.ui.list
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -16,7 +14,6 @@ import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -25,31 +22,26 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import net.uoneweb.android.receipt.R
 import net.uoneweb.android.receipt.data.ReceiptMetaData
-import net.uoneweb.android.receipt.ui.ReceiptViewModel
+
+data class ReceiptListState(
+    val yearMonthOptions: List<String> = emptyList(),
+    val selectedYearMonth: String = "",
+    val receipts: List<ReceiptMetaData> = emptyList(),
+) {
+    companion object {
+        const val UNKNOWN_DATE_KEY = "__unknown__"
+    }
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReceiptList(
-    list: List<ReceiptMetaData> = emptyList(),
-    onClickItem: (item: ReceiptMetaData) -> Unit = {},
-    viewModel: ReceiptViewModel = viewModel(),
+    state: ReceiptListState,
+    onYearMonthSelected: (String) -> Unit = {},
+    onClickItem: (ReceiptMetaData) -> Unit = {},
 ) {
-    val yearMonthList by viewModel.yearMonthList.collectAsState()
-    val unknownDateCount by viewModel.unknownDateCount.collectAsState()
-    val selectedYearMonth by viewModel.selectedYearMonth.collectAsState()
-
-    val allOptions = buildList {
-        addAll(yearMonthList)
-        if (unknownDateCount > 0) {
-            add(ReceiptViewModel.UNKNOWN_DATE_KEY)
-        }
-    }
-
-    val receipts by viewModel.getReceiptsForMonth(selectedYearMonth).collectAsState()
-
     var expanded by remember { mutableStateOf(false) }
 
     Column {
@@ -61,7 +53,7 @@ fun ReceiptList(
                 .padding(8.dp),
         ) {
             TextField(
-                value = formatYearMonth(selectedYearMonth),
+                value = formatYearMonth(state.selectedYearMonth),
                 onValueChange = {},
                 readOnly = true,
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
@@ -73,11 +65,11 @@ fun ReceiptList(
                 expanded = expanded,
                 onDismissRequest = { expanded = false },
             ) {
-                allOptions.forEach { yearMonth ->
+                state.yearMonthOptions.forEach { yearMonth ->
                     DropdownMenuItem(
                         text = { Text(formatYearMonth(yearMonth)) },
                         onClick = {
-                            viewModel.selectYearMonth(yearMonth)
+                            onYearMonthSelected(yearMonth)
                             expanded = false
                         },
                     )
@@ -85,7 +77,7 @@ fun ReceiptList(
             }
         }
 
-        receipts.forEach { item ->
+        state.receipts.forEach { item ->
             ReceiptListItem(item, onClickItem)
         }
     }
@@ -93,7 +85,7 @@ fun ReceiptList(
 
 @Composable
 private fun formatYearMonth(yearMonth: String): String {
-    return if (yearMonth == ReceiptViewModel.UNKNOWN_DATE_KEY) {
+    return if (yearMonth == ReceiptListState.UNKNOWN_DATE_KEY) {
         stringResource(R.string.list_unknown_date)
     } else {
         yearMonth.replace("-", "年") + "月"
@@ -103,7 +95,7 @@ private fun formatYearMonth(yearMonth: String): String {
 @Composable
 fun ReceiptListItem(
     item: ReceiptMetaData = ReceiptMetaData.Empty,
-    onClickItem: (item: ReceiptMetaData) -> Unit = {},
+    onClickItem: (ReceiptMetaData) -> Unit = {},
 ) {
     Row(
         modifier = Modifier
@@ -113,6 +105,18 @@ fun ReceiptListItem(
     ) {
         Text(item.content.title(), style = MaterialTheme.typography.bodyMedium)
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ReceiptListPreview() {
+    ReceiptList(
+        state = ReceiptListState(
+            yearMonthOptions = listOf("2025-01", "2025-02"),
+            selectedYearMonth = "2025-01",
+            receipts = listOf(ReceiptMetaData.Sample),
+        ),
+    )
 }
 
 @Preview(showBackground = true)

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptList.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptList.kt
@@ -5,35 +5,19 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import net.uoneweb.android.receipt.R
 import net.uoneweb.android.receipt.data.ReceiptMetaData
 
 data class ReceiptListState(
     val yearMonthOptions: List<String> = emptyList(),
     val selectedYearMonth: String = "",
     val receipts: List<ReceiptMetaData> = emptyList(),
-) {
-    companion object {
-        const val UNKNOWN_DATE_KEY = "__unknown__"
-    }
-}
+)
 
 @Composable
 fun ReceiptList(
@@ -54,56 +38,6 @@ fun ReceiptList(
         state.receipts.forEach { item ->
             ReceiptListItem(item, onClickItem)
         }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun YearMonthDropdown(
-    options: List<String>,
-    selectedYearMonth: String,
-    onYearMonthSelected: (String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    var expanded by remember { mutableStateOf(false) }
-
-    ExposedDropdownMenuBox(
-        expanded = expanded,
-        onExpandedChange = { expanded = it },
-        modifier = modifier,
-    ) {
-        TextField(
-            value = formatYearMonth(selectedYearMonth),
-            onValueChange = {},
-            readOnly = true,
-            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-            modifier = Modifier
-                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
-                .fillMaxWidth(),
-        )
-        ExposedDropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { expanded = false },
-        ) {
-            options.forEach { yearMonth ->
-                DropdownMenuItem(
-                    text = { Text(formatYearMonth(yearMonth)) },
-                    onClick = {
-                        onYearMonthSelected(yearMonth)
-                        expanded = false
-                    },
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun formatYearMonth(yearMonth: String): String {
-    return if (yearMonth == ReceiptListState.UNKNOWN_DATE_KEY) {
-        stringResource(R.string.list_unknown_date)
-    } else {
-        yearMonth.replace("-", "年") + "月"
     }
 }
 
@@ -131,16 +65,6 @@ fun ReceiptListPreview() {
             selectedYearMonth = "2025-01",
             receipts = listOf(ReceiptMetaData.Sample),
         ),
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun YearMonthDropdownPreview() {
-    YearMonthDropdown(
-        options = listOf("2025-01", "2025-02", ReceiptListState.UNKNOWN_DATE_KEY),
-        selectedYearMonth = "2025-01",
-        onYearMonthSelected = {},
     )
 }
 

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptListScreen.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptListScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
@@ -59,7 +60,6 @@ fun ReceiptListScreen(
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     val uiState by viewModel.uiState.collectAsState()
-
     val currencyFormatter = remember { NumberFormat.getCurrencyInstance(Locale.JAPAN) }
 
     Scaffold(
@@ -91,98 +91,174 @@ fun ReceiptListScreen(
                 .fillMaxSize()
                 .padding(paddingValues),
         ) {
-            when (uiState) {
-                is ReceiptListUiState.Loading -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        CircularProgressIndicator()
+            ReceiptListContent(
+                uiState = uiState,
+                onYearMonthSelected = { viewModel.selectYearMonth(it) },
+                onReceiptClick = onReceiptClick,
+                onDeleteReceipt = { receipt ->
+                    scope.launch {
+                        viewModel.deleteReceipt(receipt)
+                        snackbarHostState.showSnackbar("レシートを削除しました")
                     }
-                }
+                },
+                currencyFormatter = currencyFormatter,
+            )
+        }
+    }
+}
 
-                is ReceiptListUiState.Empty -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Receipt,
-                                contentDescription = null,
-                                modifier = Modifier.size(64.dp),
-                            )
-                            Spacer(modifier = Modifier.height(16.dp))
-                            Text(
-                                text = stringResource(R.string.list_empty),
-                                style = MaterialTheme.typography.bodyLarge,
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Text(
-                                text = stringResource(R.string.list_empty_description),
-                                style = MaterialTheme.typography.bodyMedium,
-                            )
-                        }
-                    }
-                }
+@Composable
+private fun ReceiptListContent(
+    uiState: ReceiptListUiState,
+    onYearMonthSelected: (String) -> Unit,
+    onReceiptClick: (Long) -> Unit,
+    onDeleteReceipt: (ReceiptMetaData) -> Unit,
+    currencyFormatter: NumberFormat,
+) {
+    when (uiState) {
+        is ReceiptListUiState.Loading -> ReceiptListLoading()
+        is ReceiptListUiState.Empty -> ReceiptListEmpty()
+        is ReceiptListUiState.Success -> ReceiptListSuccess(
+            state = uiState,
+            onYearMonthSelected = onYearMonthSelected,
+            onReceiptClick = onReceiptClick,
+            onDeleteReceipt = onDeleteReceipt,
+            currencyFormatter = currencyFormatter,
+        )
+        is ReceiptListUiState.Error -> ReceiptListError(uiState.message)
+    }
+}
 
-                is ReceiptListUiState.Success -> {
-                    val successState = uiState as ReceiptListUiState.Success
+@Composable
+private fun ReceiptListLoading() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}
 
-                    Column(modifier = Modifier.fillMaxSize()) {
-                        YearMonthDropdown(
-                            options = successState.yearMonthOptions,
-                            selectedYearMonth = successState.selectedYearMonth,
-                            onYearMonthSelected = { viewModel.selectYearMonth(it) },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(16.dp),
-                        )
+@Composable
+private fun ReceiptListEmpty() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Receipt,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(R.string.list_empty),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.list_empty_description),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
 
-                        LazyColumn(
-                            modifier = Modifier.fillMaxSize(),
-                        ) {
-                            items(
-                                items = successState.receipts,
-                                key = { it.id ?: 0 },
-                            ) { receipt ->
-                                ReceiptItem(
-                                    receipt = receipt,
-                                    currencyFormatter = currencyFormatter,
-                                    onReceiptClick = { onReceiptClick(receipt.id!!) },
-                                    onDeleteClick = {
-                                        scope.launch {
-                                            viewModel.deleteReceipt(receipt)
-                                            snackbarHostState.showSnackbar(
-                                                "レシートを削除しました",
-                                            )
-                                        }
-                                    },
-                                )
-                            }
-                        }
-                    }
-                }
+@Composable
+private fun ReceiptListSuccess(
+    state: ReceiptListUiState.Success,
+    onYearMonthSelected: (String) -> Unit,
+    onReceiptClick: (Long) -> Unit,
+    onDeleteReceipt: (ReceiptMetaData) -> Unit,
+    currencyFormatter: NumberFormat,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        YearMonthDropdown(
+            options = state.yearMonthOptions,
+            selectedYearMonth = state.selectedYearMonth,
+            onYearMonthSelected = onYearMonthSelected,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        )
 
-                is ReceiptListUiState.Error -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Text(
-                            text = stringResource(
-                                R.string.list_error,
-                                (uiState as ReceiptListUiState.Error).message,
-                            ),
-                            color = MaterialTheme.colorScheme.error,
-                        )
-                    }
-                }
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            items(
+                items = state.receipts,
+                key = { it.id ?: 0 },
+            ) { receipt ->
+                ReceiptItem(
+                    receipt = receipt,
+                    currencyFormatter = currencyFormatter,
+                    onReceiptClick = { onReceiptClick(receipt.id!!) },
+                    onDeleteClick = { onDeleteReceipt(receipt) },
+                )
             }
         }
     }
+}
+
+@Composable
+private fun ReceiptListError(message: String) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = stringResource(R.string.list_error, message),
+            color = MaterialTheme.colorScheme.error,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ReceiptListLoadingPreview() {
+    ReceiptListLoading()
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ReceiptListEmptyPreview() {
+    ReceiptListEmpty()
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ReceiptListSuccessPreview() {
+    ReceiptListSuccess(
+        state = ReceiptListUiState.Success(
+            yearMonthOptions = listOf("2025-01", "2025-02"),
+            selectedYearMonth = "2025-01",
+            receipts = listOf(ReceiptMetaData.Sample),
+        ),
+        onYearMonthSelected = {},
+        onReceiptClick = {},
+        onDeleteReceipt = {},
+        currencyFormatter = NumberFormat.getCurrencyInstance(Locale.JAPAN),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ReceiptListErrorPreview() {
+    ReceiptListError("エラーが発生しました")
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ReceiptItemPreview() {
+    ReceiptItem(
+        receipt = ReceiptMetaData.Sample,
+        currencyFormatter = NumberFormat.getCurrencyInstance(Locale.JAPAN),
+        onReceiptClick = {},
+        onDeleteClick = {},
+    )
 }
 
 @Composable

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptListScreen.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptListScreen.kt
@@ -1,3 +1,5 @@
+package net.uoneweb.android.receipt.ui.list
+
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -19,22 +21,28 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Receipt
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -45,10 +53,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
 import net.uoneweb.android.receipt.R
 import net.uoneweb.android.receipt.data.ReceiptMetaData
-import net.uoneweb.android.receipt.ui.list.ReceiptListUiState
-import net.uoneweb.android.receipt.ui.list.ReceiptListViewModel
 import java.text.NumberFormat
-import java.text.SimpleDateFormat
 import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -62,7 +67,6 @@ fun ReceiptListScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val uiState by viewModel.uiState.collectAsState()
 
-    val dateFormatter = remember { SimpleDateFormat("yyyy/MM/dd", Locale.getDefault()) }
     val currencyFormatter = remember { NumberFormat.getCurrencyInstance(Locale.JAPAN) }
 
     Scaffold(
@@ -132,26 +136,65 @@ fun ReceiptListScreen(
                 }
 
                 is ReceiptListUiState.Success -> {
-                    val receipts = (uiState as ReceiptListUiState.Success).receipts
-                    LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
-                    ) {
-                        items(receipts) { receipt ->
-                            ReceiptItem(
-                                receipt = receipt,
-                                dateFormatter = dateFormatter,
-                                currencyFormatter = currencyFormatter,
-                                onReceiptClick = { onReceiptClick(receipt.id!!) },
-                                onDeleteClick = {
-                                    scope.launch {
-                                        viewModel.deleteReceipt(receipt)
-                                        snackbarHostState.showSnackbar(
-                                            "レシートを削除しました",
-                                        )
-                                    }
+                    val successState = uiState as ReceiptListUiState.Success
+                    var expanded by remember { mutableStateOf(false) }
+
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        ExposedDropdownMenuBox(
+                            expanded = expanded,
+                            onExpandedChange = { expanded = it },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                        ) {
+                            TextField(
+                                value = formatYearMonth(successState.selectedYearMonth),
+                                onValueChange = {},
+                                readOnly = true,
+                                trailingIcon = {
+                                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
                                 },
+                                modifier = Modifier
+                                    .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                                    .fillMaxWidth(),
                             )
-                            HorizontalDivider()
+                            ExposedDropdownMenu(
+                                expanded = expanded,
+                                onDismissRequest = { expanded = false },
+                            ) {
+                                successState.yearMonthOptions.forEach { yearMonth ->
+                                    DropdownMenuItem(
+                                        text = { Text(formatYearMonth(yearMonth)) },
+                                        onClick = {
+                                            viewModel.selectYearMonth(yearMonth)
+                                            expanded = false
+                                        },
+                                    )
+                                }
+                            }
+                        }
+
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                        ) {
+                            items(
+                                items = successState.receipts,
+                                key = { it.id ?: 0 },
+                            ) { receipt ->
+                                ReceiptItem(
+                                    receipt = receipt,
+                                    currencyFormatter = currencyFormatter,
+                                    onReceiptClick = { onReceiptClick(receipt.id!!) },
+                                    onDeleteClick = {
+                                        scope.launch {
+                                            viewModel.deleteReceipt(receipt)
+                                            snackbarHostState.showSnackbar(
+                                                "レシートを削除しました",
+                                            )
+                                        }
+                                    },
+                                )
+                            }
                         }
                     }
                 }
@@ -176,9 +219,17 @@ fun ReceiptListScreen(
 }
 
 @Composable
+private fun formatYearMonth(yearMonth: String): String {
+    return if (yearMonth == ReceiptListViewModel.UNKNOWN_DATE_KEY) {
+        stringResource(R.string.list_unknown_date)
+    } else {
+        yearMonth.replace("-", "年") + "月"
+    }
+}
+
+@Composable
 fun ReceiptItem(
     receipt: ReceiptMetaData,
-    dateFormatter: SimpleDateFormat,
     currencyFormatter: NumberFormat,
     onReceiptClick: () -> Unit,
     onDeleteClick: () -> Unit,
@@ -186,35 +237,33 @@ fun ReceiptItem(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = 16.dp, vertical = 4.dp)
             .clickable(onClick = onReceiptClick),
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
+                .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
                 imageVector = Icons.Default.Receipt,
                 contentDescription = null,
-                modifier = Modifier.size(40.dp),
+                modifier = Modifier.size(32.dp),
             )
 
-            Spacer(modifier = Modifier.width(16.dp))
+            Spacer(modifier = Modifier.width(12.dp))
 
             Column(
                 modifier = Modifier.weight(1f),
             ) {
                 Text(
                     text = receipt.content.store.name,
-                    style = MaterialTheme.typography.titleMedium,
+                    style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.Bold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
-
-                Spacer(modifier = Modifier.height(4.dp))
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -227,7 +276,7 @@ fun ReceiptItem(
                     }
                     Text(
                         text = date,
-                        style = MaterialTheme.typography.bodyMedium,
+                        style = MaterialTheme.typography.bodySmall,
                     )
 
                     Text(
@@ -237,8 +286,6 @@ fun ReceiptItem(
                     )
                 }
             }
-
-            Spacer(modifier = Modifier.width(8.dp))
 
             IconButton(onClick = onDeleteClick) {
                 Icon(
@@ -250,5 +297,3 @@ fun ReceiptItem(
         }
     }
 }
-
-

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptListScreen.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptListScreen.kt
@@ -21,28 +21,21 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Receipt
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -137,42 +130,16 @@ fun ReceiptListScreen(
 
                 is ReceiptListUiState.Success -> {
                     val successState = uiState as ReceiptListUiState.Success
-                    var expanded by remember { mutableStateOf(false) }
 
                     Column(modifier = Modifier.fillMaxSize()) {
-                        ExposedDropdownMenuBox(
-                            expanded = expanded,
-                            onExpandedChange = { expanded = it },
+                        YearMonthDropdown(
+                            options = successState.yearMonthOptions,
+                            selectedYearMonth = successState.selectedYearMonth,
+                            onYearMonthSelected = { viewModel.selectYearMonth(it) },
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(16.dp),
-                        ) {
-                            TextField(
-                                value = formatYearMonth(successState.selectedYearMonth),
-                                onValueChange = {},
-                                readOnly = true,
-                                trailingIcon = {
-                                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
-                                },
-                                modifier = Modifier
-                                    .menuAnchor(MenuAnchorType.PrimaryNotEditable)
-                                    .fillMaxWidth(),
-                            )
-                            ExposedDropdownMenu(
-                                expanded = expanded,
-                                onDismissRequest = { expanded = false },
-                            ) {
-                                successState.yearMonthOptions.forEach { yearMonth ->
-                                    DropdownMenuItem(
-                                        text = { Text(formatYearMonth(yearMonth)) },
-                                        onClick = {
-                                            viewModel.selectYearMonth(yearMonth)
-                                            expanded = false
-                                        },
-                                    )
-                                }
-                            }
-                        }
+                        )
 
                         LazyColumn(
                             modifier = Modifier.fillMaxSize(),
@@ -215,15 +182,6 @@ fun ReceiptListScreen(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun formatYearMonth(yearMonth: String): String {
-    return if (yearMonth == ReceiptListViewModel.UNKNOWN_DATE_KEY) {
-        stringResource(R.string.list_unknown_date)
-    } else {
-        yearMonth.replace("-", "年") + "月"
     }
 }
 

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptListViewModel.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptListViewModel.kt
@@ -3,34 +3,65 @@ package net.uoneweb.android.receipt.ui.list
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import net.uoneweb.android.receipt.data.ReceiptMetaData
 import net.uoneweb.android.receipt.repository.ReceiptMetaDataRepository
+import java.util.Calendar
 
 /**
  * ViewModel for the Receipt List screen.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class ReceiptListViewModel(
     application: Application,
 ) : AndroidViewModel(application) {
 
     private val repository = ReceiptMetaDataRepository(application)
 
+    private val _selectedYearMonth = MutableStateFlow(getCurrentYearMonth())
+    val selectedYearMonth: StateFlow<String> = _selectedYearMonth
+
+    private val yearMonthListFlow = repository.getYearMonthList()
+    private val unknownCountFlow = repository.getCountUnknownDate()
+
+    private val selectedReceiptsFlow = _selectedYearMonth.flatMapLatest { yearMonth ->
+        if (yearMonth == UNKNOWN_DATE_KEY) {
+            repository.getUnknownDate()
+        } else {
+            repository.getByYearMonth(yearMonth)
+        }
+    }
+
     /**
      * UI state for the Receipt List screen.
      */
-    val uiState: StateFlow<ReceiptListUiState> = repository.getAll()
-        .map { receipts ->
-            if (receipts.isEmpty()) {
-                ReceiptListUiState.Empty
-            } else {
-                ReceiptListUiState.Success(receipts)
+    val uiState: StateFlow<ReceiptListUiState> = combine(
+        yearMonthListFlow,
+        unknownCountFlow,
+        _selectedYearMonth,
+        selectedReceiptsFlow,
+    ) { yearMonthList, unknownCount, selectedYearMonth, receipts ->
+        if (yearMonthList.isEmpty() && unknownCount == 0) {
+            ReceiptListUiState.Empty
+        } else {
+            val options = yearMonthList.toMutableList()
+            if (unknownCount > 0) {
+                options.add(UNKNOWN_DATE_KEY)
             }
+            ReceiptListUiState.Success(
+                yearMonthOptions = options,
+                selectedYearMonth = selectedYearMonth,
+                receipts = receipts,
+            )
         }
+    }
         .catch { e ->
             emit(ReceiptListUiState.Error(e.message ?: "Unknown error"))
         }
@@ -40,11 +71,26 @@ class ReceiptListViewModel(
             initialValue = ReceiptListUiState.Loading,
         )
 
+    fun selectYearMonth(yearMonth: String) {
+        _selectedYearMonth.value = yearMonth
+    }
+
     /**
      * Deletes a receipt.
      */
     suspend fun deleteReceipt(receipt: ReceiptMetaData) {
         repository.delete(receipt)
+    }
+
+    companion object {
+        const val UNKNOWN_DATE_KEY = "__unknown__"
+
+        private fun getCurrentYearMonth(): String {
+            val now = Calendar.getInstance()
+            val year = now.get(Calendar.YEAR)
+            val month = now.get(Calendar.MONTH) + 1
+            return String.format("%04d-%02d", year, month)
+        }
     }
 }
 
@@ -54,6 +100,10 @@ class ReceiptListViewModel(
 sealed class ReceiptListUiState {
     data object Loading : ReceiptListUiState()
     data object Empty : ReceiptListUiState()
-    data class Success(val receipts: List<ReceiptMetaData>) : ReceiptListUiState()
+    data class Success(
+        val yearMonthOptions: List<String>,
+        val selectedYearMonth: String,
+        val receipts: List<ReceiptMetaData>,
+    ) : ReceiptListUiState()
     data class Error(val message: String) : ReceiptListUiState()
 }

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptListViewModel.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/ReceiptListViewModel.kt
@@ -11,9 +11,10 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
+import net.uoneweb.android.receipt.UNKNOWN_DATE_KEY
+import net.uoneweb.android.receipt.currentYearMonth
 import net.uoneweb.android.receipt.data.ReceiptMetaData
 import net.uoneweb.android.receipt.repository.ReceiptMetaDataRepository
-import java.util.Calendar
 
 /**
  * ViewModel for the Receipt List screen.
@@ -25,7 +26,7 @@ class ReceiptListViewModel(
 
     private val repository = ReceiptMetaDataRepository(application)
 
-    private val _selectedYearMonth = MutableStateFlow(getCurrentYearMonth())
+    private val _selectedYearMonth = MutableStateFlow(currentYearMonth())
     val selectedYearMonth: StateFlow<String> = _selectedYearMonth
 
     private val yearMonthListFlow = repository.getYearMonthList()
@@ -82,16 +83,6 @@ class ReceiptListViewModel(
         repository.delete(receipt)
     }
 
-    companion object {
-        const val UNKNOWN_DATE_KEY = "__unknown__"
-
-        private fun getCurrentYearMonth(): String {
-            val now = Calendar.getInstance()
-            val year = now.get(Calendar.YEAR)
-            val month = now.get(Calendar.MONTH) + 1
-            return String.format("%04d-%02d", year, month)
-        }
-    }
 }
 
 /**

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/YearMonthDropdown.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/YearMonthDropdown.kt
@@ -17,8 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import net.uoneweb.android.receipt.R
-
-const val UNKNOWN_DATE_KEY = "__unknown__"
+import net.uoneweb.android.receipt.UNKNOWN_DATE_KEY
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/YearMonthDropdown.kt
+++ b/receipt/src/main/java/net/uoneweb/android/receipt/ui/list/YearMonthDropdown.kt
@@ -1,0 +1,81 @@
+package net.uoneweb.android.receipt.ui.list
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import net.uoneweb.android.receipt.R
+
+const val UNKNOWN_DATE_KEY = "__unknown__"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun YearMonthDropdown(
+    options: List<String>,
+    selectedYearMonth: String,
+    onYearMonthSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        TextField(
+            value = formatYearMonth(selectedYearMonth),
+            onValueChange = {},
+            readOnly = true,
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .fillMaxWidth(),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            options.forEach { yearMonth ->
+                DropdownMenuItem(
+                    text = { Text(formatYearMonth(yearMonth)) },
+                    onClick = {
+                        onYearMonthSelected(yearMonth)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun formatYearMonth(yearMonth: String): String {
+    return if (yearMonth == UNKNOWN_DATE_KEY) {
+        stringResource(R.string.list_unknown_date)
+    } else {
+        yearMonth.replace("-", "年") + "月"
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun YearMonthDropdownPreview() {
+    YearMonthDropdown(
+        options = listOf("2025-01", "2025-02", UNKNOWN_DATE_KEY),
+        selectedYearMonth = "2025-01",
+        onYearMonthSelected = {},
+    )
+}

--- a/receipt/src/main/res/values/strings.xml
+++ b/receipt/src/main/res/values/strings.xml
@@ -9,5 +9,9 @@
     <string name="list_error">エラー： %1$s</string>
     <string name="detail_date_unknown">不明</string>
     <string name="list_delete">削除</string>
+    <string name="list_unknown_date">日付不明</string>
+    <string name="list_group_count">%1$d件</string>
+    <string name="list_expand">展開</string>
+    <string name="list_collapse">折りたたむ</string>
     <string name="find_with_map">地図を開く</string>
 </resources>


### PR DESCRIPTION
## Summary
- レシート一覧画面のパフォーマンス改善のため、年月でフィルタリング表示するように変更
- DBレベルで年月インデックスを追加し、年月指定でのクエリに対応
- Compose のベストプラクティスに従いコンポーネントを分割・リファクタリング
- .gitignore に開発ツール関連のエントリを追加

## Changes
- `ReceiptMetaDataEntity`: `receiptDate`, `receiptYearMonth` カラム追加（インデックス付き）
- `ReceiptMetaDataDao`: 年月リスト取得、年月指定クエリ追加
- `YearMonthDropdown`: 年月選択用ドロップダウンを別コンポーネントに分離
- `ReceiptListScreen`: コンポーネント分割と Preview 追加
- State hoisting パターン適用（ViewModel から State を公開）

## Test plan
- [x] アプリをビルドして起動できることを確認
- [x] レシート一覧画面でドロップダウンから年月を選択できることを確認
- [x] 選択した年月のレシートのみが表示されることを確認
- [x] 日付不明のレシートが「日付不明」オプションで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)